### PR TITLE
Support latest BeagleBone Black Kernel

### DIFF
--- a/bulldog-board-beagleboneblack/src/main/java/io/silverspoon/bulldog/beagleboneblack/BeagleBoneBlack.java
+++ b/bulldog-board-beagleboneblack/src/main/java/io/silverspoon/bulldog/beagleboneblack/BeagleBoneBlack.java
@@ -240,7 +240,7 @@ public class BeagleBoneBlack extends AbstractBoard implements FeatureActivationL
 
    private void createI2cBuses() {
       //getI2cBuses().add(new LinuxI2cBus(BBBNames.I2C_0, "/dev/i2c-0"));
-      getI2cBuses().add(new LinuxI2cBus(BBBNames.I2C_1, "/dev/i2c-1"));
+      getI2cBuses().add(new LinuxI2cBus(BBBNames.I2C_1, "/dev/i2c-2"));
    }
 
    private void createSpiBuses() {


### PR DESCRIPTION
/dev/i2c-1 is incorrect on the latest BeagleBone images.  Use /dev/i2c-2 to get a proper connection.